### PR TITLE
Grid

### DIFF
--- a/src/scss/components/grid/_base.scss
+++ b/src/scss/components/grid/_base.scss
@@ -1,3 +1,5 @@
+$column-number: 12;
+
 .Container {
   width: 100%;
 }
@@ -12,13 +14,25 @@
   min-height: 1px;
   font-size: 1rem;
   word-wrap: break-word;
+  vertical-align: top;
 }
 
 // Generate columns
 
 @for $i from 1 to ($column-number + 1) {
-
   .Column-#{$i} {
     width: percentage(($i/$column-number));
   }
+}
+
+.Column--alignTop {
+  vertical-align: top;
+}
+
+.Column--alignMiddle {
+  vertical-align: middle;
+}
+
+.Column--alignBottom {
+  vertical-align: bottom;
 }

--- a/src/scss/components/grid/_base.scss
+++ b/src/scss/components/grid/_base.scss
@@ -3,13 +3,14 @@
 }
 
 .Row {
-  @include cf();
+  font-size: 0;
 }
 
 .Column {
+  display: inline-block;
   position: relative;
-  float: left;
   min-height: 1px;
+  font-size: 1rem;
   word-wrap: break-word;
 }
 
@@ -19,10 +20,5 @@
 
   .Column-#{$i} {
     width: percentage(($i/$column-number));
-
-    @if $i == 12 {
-      float: none;
-      width: auto;
-    }
   }
 }

--- a/src/scss/components/grid/grid.md
+++ b/src/scss/components/grid/grid.md
@@ -71,3 +71,41 @@ You can overide the `$column-number` variable
   </div>
 </div>
 ```
+
+## Columns alignment
+
+### Align top
+
+```html
+<div class="Container">
+  <div class="Row">
+    <div class="Column Column-4 Column--alignTop">Sorry boss but there's only two men I trust. One of them's me. The other's not you.</div>
+    <div class="Column Column-4">Put... the bunny... back... in the box.</div>
+    <div class="Column Column-4">I'm gonna save the fuckin' day!</div>
+  </div>
+</div>
+```
+
+### Align middle
+
+```html
+<div class="Container">
+  <div class="Row">
+    <div class="Column Column-4 Column--alignMiddle">Sorry boss but there's only two men I trust. One of them's me. The other's not you.</div>
+    <div class="Column Column-4 Column--alignMiddle">Put... the bunny... back... in the box.</div>
+    <div class="Column Column-4 ">Sorry boss but there's only two men I trust. One of them's me. The other's not you.</div>
+  </div>
+</div>
+```
+
+### Align bottom
+
+```html
+<div class="Container">
+  <div class="Row">
+    <div class="Column Column-4">Sorry boss but there's only two men I trust. One of them's me. The other's not you.</div>
+    <div class="Column Column-4 Column--alignBottom">Put... the bunny... back... in the box.</div>
+    <div class="Column Column-4">I'm gonna save the fuckin' day!</div>
+  </div>
+</div>
+```

--- a/src/scss/utils/_vars.scss
+++ b/src/scss/utils/_vars.scss
@@ -37,13 +37,8 @@ $margin--l: $base-margin * 2;
 
 
 // Radius
+
 $base-radius: rem(3px) !default;
-
-
-
-// Grid
-
-$column-number: 12;
 
 
 


### PR DESCRIPTION
Easier way to manage RTL layouts
- Kill floats
- Using `display: inline-block`
- Remove white spaces with `font-size: 0`on `.Row`
- `.Column` modifier to be able to position the column on top/middle/bottom
