### PR TITLE
Gulp tasks and NPM scripts enhancements

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,136 +1,16 @@
-var bs          = require('browser-sync');
-var deploy      = require('gulp-gh-pages');
-var gulp        = require('gulp');
-var linter      = require('gulp-scss-lint');
-var prefix      = require('gulp-autoprefixer');
-var sass        = require('gulp-sass');
-var sourcemaps  = require('gulp-sourcemaps');
-var Styleguide  = require('styleguide-generator');
-var sketch      = require('gulp-sketch');
-var iconfont    = require('gulp-iconfont');
-var consolidate = require('gulp-consolidate');
-var filter      = require('gulp-filter');
-var stylestats  = require('gulp-stylestats');
-var rename      = require('gulp-rename');
-var execsync    = require('execsync');
+gulp = require('gulp');
 
-var MyStyleguide = new Styleguide({
-	files: {
-		src: 'src/scss',
-		dist: 'dist/',
-		colors: 'src/scss/utils/var/_color-values.scss'
-	},
-	type: 'onepage',
-	onepage: {
-		layout: 'styleguide/layout.html',
-		stylesheets: [
-			'styleguide/styleguide.css',
-			'styleguide/code-style.css'
-		]
-	},
-	components: {
-		extension: 'html'
-	}
-});
-
-function handleError (error) {
+handleError = function (error) {
 	console.log('Error: ' + error);
 	this.emit('end');
-}
+};
 
-gulp.task('sass', function () {
-  return gulp.src('./src/scss/**/*.scss')
-		.pipe(linter({
-      'config': './scss-lint.yml'
-    }))
-		.on('error', handleError)
-		.pipe(sourcemaps.init())
-    .pipe(sass())
-		.on('error', handleError)
-		.pipe(sourcemaps.write())
-    .pipe(prefix({
-      browsers: ['last 2 versions']
-    }))
-    .pipe(gulp.dest('./dist'));
-});
-
-gulp.task('icons', function(){
-  return gulp.src('src/sketch/icons.sketch')
-    .pipe(sketch({
-      export: 'slices',
-      formats: 'svg',
-      compact: 'yes',
-      saveForWeb: 'yes'
-    }))
-    .pipe(iconfont({
-      fontName: 'icons',
-      appendCodepoints: false,
-      normalize: true,
-      centerHorizontally: true,
-      fontHeight: 100
-    }))
-    .on('glyphs', function(glyphs, options) {
-      gulp.src('src/scss/components/icons/templates/_base.scss.tpl')
-        .pipe(consolidate('lodash', {
-          glyphs: glyphs,
-          fontName: 'icons',
-          className: 'Icon'
-        }))
-      .pipe(rename('_base.scss'))
-      .pipe(gulp.dest('src/scss/components/icons/'))
-
-      gulp.src('src/scss/components/icons/templates/_icons.md.tpl')
-        .pipe(consolidate('lodash', {
-          glyphs: glyphs,
-          fontName: 'icons',
-          className: 'Icon'
-        }))
-        .pipe(rename('icons.md'))
-        .pipe(gulp.dest('src/scss/components/icons/'))
-    })
-    .pipe(gulp.dest('dist/fonts/'))
-})
-
-
-gulp.task('styleguide', function () {
-  return MyStyleguide.generate(function () {
-		return console.log('✓ Styleguide generated');
-   });
-});
-
-gulp.task('serve', function() {
-	return bs({
-		files: ['./dist/**/*'],
-		server: {
-			baseDir: './dist/'
-		}
-	});
-});
-
-gulp.task('stylestats', function () {
-  gulp.src('./dist/*.css')
-    .pipe(stylestats());
-});
-
-gulp.task('deploy', function () {
-	return gulp.src(['dist/**/*'])
-		.pipe(deploy());
-});
-
-gulp.task('watch', function () {
-  gulp.watch(['./src/scss/**/*.scss'], ['sass']);
-  gulp.watch(['./src/**/*.md'], ['styleguide']);
-  gulp.watch(['./styleguide/**'], ['styleguide']);
-});
-
-gulp.task('default', ['sass', 'styleguide', 'watch', 'serve']);
-
-gulp.task('vtests:ref', function () {
-	return execsync('cd ./node_modules/backstopjs && gulp reference');
-});
-
-gulp.task('vtests:compare', ['sass', 'styleguide'], function () {
-	return execsync('cd ./node_modules/backstopjs && gulp test');
-});
+gulp.task('sass',       require('./gulp-tasks/sass'));
+gulp.task('icons',      require('./gulp-tasks/icons'));
+gulp.task('serve',      require('./gulp-tasks/browser-sync'));
+gulp.task('stats',      require('./gulp-tasks/stats'));
+gulp.task('watch',      require('./gulp-tasks/watch'));
+gulp.task('deploy',     require('./gulp-tasks/deploy'));
+gulp.task('styleguide', require('./gulp-tasks/styleguide'));
 
 gulp.task('default', ['sass', 'styleguide', 'watch', 'serve']);

--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ git ci -n
 git ci -nm "My commit message"
 ```
 
-### Gulp scripts
+### NPM scripts
 
 ```js
   // build references
-  gulp vtests:ref
+  npm run vt:refs
 
   // compare references with actual HEAD
-  gulp vtests:compare
+  npm run vt:compare
 ```
 
 

--- a/backstop.json
+++ b/backstop.json
@@ -34,9 +34,9 @@
         ".Dropdown",
         ".Dropdown-item",
 
-        ".Flash",
-
         ".Meter",
+
+        ".Notification",
 
         ".Pellet",
 

--- a/gulp-tasks/browser-sync.js
+++ b/gulp-tasks/browser-sync.js
@@ -1,0 +1,10 @@
+var bs = require('browser-sync');
+
+module.exports = function () {
+  return bs({
+		files: ['./dist/**/*'],
+		server: {
+			baseDir: './dist/'
+		}
+	});
+};

--- a/gulp-tasks/deploy.js
+++ b/gulp-tasks/deploy.js
@@ -1,0 +1,6 @@
+var deploy = require('gulp-gh-pages');
+
+module.exports = function () {
+	return gulp.src(['dist/**/*'])
+		.pipe(deploy());
+};

--- a/gulp-tasks/icons.js
+++ b/gulp-tasks/icons.js
@@ -1,0 +1,41 @@
+var rename      = require('gulp-rename');
+var sketch      = require('gulp-sketch');
+var iconfont    = require('gulp-iconfont');
+var consolidate = require('gulp-consolidate');
+
+module.exports = function () {
+  return gulp.src('src/sketch/icons.sketch')
+    .pipe(sketch({
+      export: 'slices',
+      formats: 'svg',
+      compact: 'yes',
+      saveForWeb: 'yes'
+    }))
+    .pipe(iconfont({
+      fontName: 'icons',
+      appendCodepoints: false,
+      normalize: true,
+      centerHorizontally: true,
+      fontHeight: 100
+    }))
+    .on('glyphs', function(glyphs, options) {
+      gulp.src('src/scss/components/icons/templates/_base.scss.tpl')
+        .pipe(consolidate('lodash', {
+          glyphs: glyphs,
+          fontName: 'icons',
+          className: 'Icon'
+        }))
+      .pipe(rename('_base.scss'))
+      .pipe(gulp.dest('src/scss/components/icons/'));
+
+      gulp.src('src/scss/components/icons/templates/_icons.md.tpl')
+        .pipe(consolidate('lodash', {
+          glyphs: glyphs,
+          fontName: 'icons',
+          className: 'Icon'
+        }))
+        .pipe(rename('icons.md'))
+        .pipe(gulp.dest('src/scss/components/icons/'));
+    })
+    .pipe(gulp.dest('dist/fonts/'));
+};

--- a/gulp-tasks/sass.js
+++ b/gulp-tasks/sass.js
@@ -1,0 +1,19 @@
+var sass       = require('gulp-sass');
+var linter     = require('gulp-scss-lint');
+var prefix     = require('gulp-autoprefixer');
+var sourcemaps = require('gulp-sourcemaps');
+
+module.exports = function () {
+  return gulp.src('./src/scss/**/*.scss')
+		.pipe(linter({
+      'config': './scss-lint.yml'
+    }))
+		.on('error', handleError)
+		.pipe(sourcemaps.init())
+		.pipe(sass.sync().on('error', sass.logError))
+		.pipe(sourcemaps.write())
+    .pipe(prefix({
+      browsers: ['last 2 versions']
+    }))
+    .pipe(gulp.dest('./dist'));
+};

--- a/gulp-tasks/stats.js
+++ b/gulp-tasks/stats.js
@@ -1,0 +1,6 @@
+var stylestats = require('gulp-stylestats');
+
+module.exports = function () {
+  return gulp.src('./dist/*.css')
+    .pipe(stylestats());
+};

--- a/gulp-tasks/styleguide.js
+++ b/gulp-tasks/styleguide.js
@@ -1,0 +1,25 @@
+var Styleguide  = require('styleguide-generator');
+var styleguide  = new Styleguide({
+	files: {
+		src: 'src/scss',
+		dist: 'dist/',
+		colors: 'src/scss/utils/var/_color-values.scss'
+	},
+	type: 'onepage',
+	onepage: {
+		layout: 'styleguide/layout.html',
+		stylesheets: [
+			'styleguide/styleguide.css',
+			'styleguide/code-style.css'
+		]
+	},
+	components: {
+		extension: 'html'
+	}
+});
+
+module.exports = function () {
+  return styleguide.generate(function () {
+		return console.log('✓ Styleguide generated');
+   });
+};

--- a/gulp-tasks/watch.js
+++ b/gulp-tasks/watch.js
@@ -1,0 +1,5 @@
+module.exports = function () {
+  gulp.watch(['./src/scss/**/*.scss'], ['sass']);
+  gulp.watch(['./src/**/*.md'], ['styleguide']);
+  gulp.watch(['./styleguide/**'], ['styleguide']);
+};

--- a/package.json
+++ b/package.json
@@ -6,11 +6,9 @@
   "devDependencies": {
     "backstopjs": "^0.4.3",
     "browser-sync": "^2.2.1",
-    "execsync": "0.0.6",
     "gulp": "3.9.0",
     "gulp-autoprefixer": "2.3.1",
     "gulp-consolidate": "0.1.2",
-    "gulp-filter": "2.0.2",
     "gulp-gh-pages": "0.4.0",
     "gulp-iconfont": "3.0.2",
     "gulp-rename": "1.2.0",
@@ -23,7 +21,8 @@
     "styleguide-generator": "0.4.0"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "vt:refs": "cd ./node_modules/backstopjs && gulp reference && cd ../../",
+    "vt:compare": "cd ./node_modules/backstopjs && gulp test && cd ../../"
   },
   "repository": {
     "type": "git",

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -14,16 +14,16 @@ if [ "$COMPARE_REFS" == "y" ]; then
   echo "> git stash -q --keep-index";
   git stash -q --keep-index
 
-  echo "> gulp vtests:ref";
-  gulp vtests:ref
+  echo "> npm run vt:refs";
+  npm run vt:refs
 
   echo "> git stash pop -q"
   git stash pop -q
 
   echo "Comparing refs...";
-  echo "> gulp vtests:compare";
+  echo "> npm run vt:compare";
 
-  gulp vtests:compare
+  npm run vt:compare
 
   echo "";
   read -p "Continue? (y/n)" CONTINUE


### PR DESCRIPTION
- [x] Split Gulp tasks
- [x] Use NPM scripts instead of Gulp for visual tests (Gulp tasks hide logs in console)
- [x] Fix Backstop.json (.Flash is no longer use)

---

:warning: **Update your pre-commit** :warning:
