### PR TITLE
Dropdown | Adds custom events on open/close

### DIFF
--- a/dist/js/tapestry.js
+++ b/dist/js/tapestry.js
@@ -82,11 +82,13 @@
       Dropdown.closeAll();
       this.activeItem();
       this.$toggle.attr('aria-expanded', true);
+      this.$el.trigger('tapestry:dropdown:open');
       this.$el.focus();
     },
 
     close: function () {
       this.$toggle.attr('aria-expanded', false);
+      this.$el.trigger('tapestry:dropdown:close');
     },
 
     toggle: function () {
@@ -164,6 +166,7 @@
 
   Dropdown.closeAll = function () {
     $(selectors.toggle + '[aria-expanded=true]').attr('aria-expanded', false);
+    $(selectors.dropdown).trigger('tapestry:dropdown:close');
   };
 
   $(document).on('click.dropdown.tapestry', function (event) { Dropdown.closeAll(); });

--- a/src/js/dropdown.js
+++ b/src/js/dropdown.js
@@ -82,11 +82,13 @@
       Dropdown.closeAll();
       this.activeItem();
       this.$toggle.attr('aria-expanded', true);
+      this.$el.trigger('tapestry:dropdown:open');
       this.$el.focus();
     },
 
     close: function () {
       this.$toggle.attr('aria-expanded', false);
+      this.$el.trigger('tapestry:dropdown:close');
     },
 
     toggle: function () {
@@ -164,6 +166,7 @@
 
   Dropdown.closeAll = function () {
     $(selectors.toggle + '[aria-expanded=true]').attr('aria-expanded', false);
+    $(selectors.dropdown).trigger('tapestry:dropdown:close');
   };
 
   $(document).on('click.dropdown.tapestry', function (event) { Dropdown.closeAll(); });


### PR DESCRIPTION
This PR adds custom jQuery events for `close` and `open` methods.
The main goal is to be able to listen to these events and make specific decisions based on this information.

E.g.: Disable an input's blur if the associated dropdown is opened, etc...
